### PR TITLE
Add field "number_in_//" to culvert

### DIFF
--- a/mesh_tools/libs/create_shp_dlg.py
+++ b/mesh_tools/libs/create_shp_dlg.py
@@ -58,7 +58,7 @@ class dlg_create_shapefile(QDialog, FORM_CLASS):
 
     def select_bdd(self):
         """Sélection de l'emplacement de la BDD"""
-        txt, _ = QFileDialog.getSaveFileName(self, "Shapefile", "", "ESRI Shapefile (*.shp)")
+        txt, _ = QFileDialog.getSaveFileName(self, "File", "", "ESRI Shapefile (*.shp);; Geopackage (*.gpkg)")
         if txt != "":
             self.txt_file.setText(txt)
 

--- a/mesh_tools/libs/culvert_manager.py
+++ b/mesh_tools/libs/culvert_manager.py
@@ -51,6 +51,7 @@ from qgis.PyQt.QtGui import QStandardItem, QStandardItemModel
 from qgis.PyQt.QtWidgets import (
     QCheckBox,
     QComboBox,
+    QSpinBox,
     QDoubleSpinBox,
     QFileDialog,
     QLineEdit,
@@ -95,35 +96,36 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
         # Col4 - Index for Telemac
         # Col5 - Index for Uhaina
         self.culv_flds = [
-            ["NAME", QVariant.String, self.txt_name, 28, 22],
-            ["N1", QVariant.Int, None, 0, None],
-            ["N2", QVariant.Int, None, 1, None],
-            ["CE1", QVariant.Double, self.sb_ce1, 2, 6],
-            ["CE2", QVariant.Double, self.sb_ce2, 3, 7],
-            ["CS1", QVariant.Double, self.sb_cs1, 4, 8],
-            ["CS2", QVariant.Double, self.sb_cs2, 5, 9],
-            ["LARG", QVariant.Double, self.sb_larg, 6, 17],
-            ["HAUT", QVariant.Double, self.sb_haut1, 7, 18],
-            ["CLAP", QVariant.String, self.cb_clapet, 8, 20],
-            ["L12", QVariant.Double, self.sb_l12, 9, 10],
-            ["Z1", QVariant.Double, self.sb_z1, 10, 2],
-            ["Z2", QVariant.Double, self.sb_z2, 11, 5],
-            ["CV", QVariant.Double, self.sb_cv, 12, None],
-            ["C56", QVariant.Double, self.sb_c56, 13, None],
-            ["CV5", QVariant.Double, self.sb_cv5, 14, None],
-            ["C5", QVariant.Double, self.sb_c5, 15, None],
-            ["CT", QVariant.Double, self.sb_ct, 16, None],
-            ["HAUT2", QVariant.Double, self.sb_haut2, 17, 19],
-            ["FRIC", QVariant.Double, self.sb_fric, 18, None],
-            ["LENGTH", QVariant.Double, self.sb_length, 19, None],
-            ["CIRC", QVariant.Int, self.cb_circ, 20, 16],
-            ["d1", QVariant.Double, self.sb_d1, 21, 11],
-            ["d2", QVariant.Double, self.sb_d2, 22, 12],
-            ["a1", QVariant.Double, self.sb_a1, 23, 14],
-            ["a2", QVariant.Double, self.sb_a2, 24, 15],
-            ["AA", QVariant.Int, self.cb_auto_a, 25, 13],
-            ["AL", QVariant.Int, self.cb_auto_l, 26, None],
-            ["AZ", QVariant.Int, self.cb_auto_z, 27, 21],
+            ["NAME",        QVariant.String,    self.txt_name,  28, 23  ],
+            ["N1",          QVariant.Int,       None,           0,  None],
+            ["N2",          QVariant.Int,       None,           1,  None],
+            ["CE1",         QVariant.Double,    self.sb_ce1,    2, 6    ],
+            ["CE2",         QVariant.Double,    self.sb_ce2,    3, 7    ],
+            ["CS1",         QVariant.Double,    self.sb_cs1,    4, 8    ],
+            ["CS2",         QVariant.Double,    self.sb_cs2,    5, 9    ],
+            ["LARG",        QVariant.Double,    self.sb_larg,   6, 17   ],
+            ["HAUT",        QVariant.Double,    self.sb_haut1,  7, 18   ],
+            ["CLAP",        QVariant.String,    self.cb_clapet, 8, 20   ],
+            ["L12",         QVariant.Double,    self.sb_l12,    9, 10   ],
+            ["Z1",          QVariant.Double,    self.sb_z1,     10, 2   ],
+            ["Z2",          QVariant.Double,    self.sb_z2,     11, 5   ],
+            ["CV",          QVariant.Double,    self.sb_cv,     12, None],
+            ["C56",         QVariant.Double,    self.sb_c56,    13, None],
+            ["CV5",         QVariant.Double,    self.sb_cv5,    14, None],
+            ["C5",          QVariant.Double,    self.sb_c5,     15, None],
+            ["CT",          QVariant.Double,    self.sb_ct,     16, None],
+            ["HAUT2",       QVariant.Double,    self.sb_haut2,  17, 19  ],
+            ["FRIC",        QVariant.Double,    self.sb_fric,   18, None],
+            ["LENGTH",      QVariant.Double,    self.sb_length, 19, None],
+            ["CIRC",        QVariant.Int,       self.cb_circ,   20, 16  ],
+            ["d1",          QVariant.Double,    self.sb_d1,     21, 11  ],
+            ["d2",          QVariant.Double,    self.sb_d2,     22, 12  ],
+            ["a1",          QVariant.Double,    self.sb_a1,     23, 14  ],
+            ["a2",          QVariant.Double,    self.sb_a2,     24, 15  ],
+            ["AA",          QVariant.Int,       self.cb_auto_a, 25, 13  ],
+            ["NB_in_//",    QVariant.Int,       self.sb_nbre,   26, 21  ],
+            ["AL",          QVariant.Int,       self.cb_auto_l, 27, None],
+            ["AZ",          QVariant.Int,       self.cb_auto_z, 28, 22  ]
         ]
 
         self.is_opening = True
@@ -160,7 +162,7 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
         for fld in self.culv_flds:
             ctrl = fld[2]
             if ctrl:
-                if isinstance(ctrl, QDoubleSpinBox):
+                if isinstance(ctrl, QDoubleSpinBox) or isinstance(ctrl, QSpinBox):
                     ctrl.valueChanged.connect(self.ctrl_edited)
                 elif isinstance(ctrl, QComboBox):
                     ctrl.currentIndexChanged.connect(self.ctrl_edited)
@@ -233,6 +235,11 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
 
     def soft_changed(self):
         self.software_select = self.cb_software_select.currentIndex()
+        for fld in self.culv_flds:
+            ctrl=fld[2]
+            if ctrl is not None:
+                ctrl.setEnabled(fld[self.software_select+3] is not None)
+
 
     ######################################################################################
     #                                                                                    #
@@ -459,6 +466,8 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
             if ctrl:
                 if isinstance(ctrl, QDoubleSpinBox):
                     ctrl.setValue(0.0)
+                elif isinstance(ctrl, QSpinBox):
+                    ctrl.setValue(1)
                 elif isinstance(ctrl, QComboBox):
                     ctrl.setCurrentIndex(0)
                 elif isinstance(ctrl, QCheckBox):
@@ -479,6 +488,11 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
         if isinstance(ctrl, QDoubleSpinBox):
             if val is None:
                 ctrl.setValue(0.0)
+            else:
+                ctrl.setValue(val)
+        elif isinstance(ctrl, QSpinBox):
+            if val is None:
+                ctrl.setValue(1)
             else:
                 ctrl.setValue(val)
         elif isinstance(ctrl, QComboBox):
@@ -502,7 +516,7 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
                 ft = self.lay_culv.getFeature(self.cur_culv_id)
 
                 ctrl = self.sender()
-                if isinstance(ctrl, QDoubleSpinBox):
+                if isinstance(ctrl, QDoubleSpinBox) or isinstance(ctrl, QSpinBox):
                     val = ctrl.value()
                 elif isinstance(ctrl, QComboBox):
                     val = ctrl.currentIndex()
@@ -577,6 +591,8 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
                         ctrl.setValue(1.0)
                     else:
                         ctrl.setValue(0.0)
+                elif isinstance(ctrl, QSpinBox):
+                    ctrl.setValue(1)
                 elif isinstance(ctrl, QComboBox):
                     ctrl.setCurrentIndex(0)
                 elif isinstance(ctrl, QCheckBox):

--- a/mesh_tools/libs/culvert_manager.py
+++ b/mesh_tools/libs/culvert_manager.py
@@ -236,9 +236,9 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
     def soft_changed(self):
         self.software_select = self.cb_software_select.currentIndex()
         for fld in self.culv_flds:
-            ctrl=fld[2]
+            ctrl = fld[2]
             if ctrl is not None:
-                ctrl.setEnabled(fld[self.software_select+3] is not None)
+                ctrl.setEnabled(fld[self.software_select + 3] is not None)
 
 
     ######################################################################################

--- a/mesh_tools/libs/culvert_manager.py
+++ b/mesh_tools/libs/culvert_manager.py
@@ -123,9 +123,9 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
             ["a1",          QVariant.Double,    self.sb_a1,     23, 14  ],
             ["a2",          QVariant.Double,    self.sb_a2,     24, 15  ],
             ["AA",          QVariant.Int,       self.cb_auto_a, 25, 13  ],
-            ["NB_in_//",    QVariant.Int,       self.sb_nbre,   26, 21  ],
-            ["AL",          QVariant.Int,       self.cb_auto_l, 27, None],
-            ["AZ",          QVariant.Int,       self.cb_auto_z, 28, 22  ]
+            ["NB_in_//",    QVariant.Int,       self.sb_nbre,   None, 21  ],
+            ["AL",          QVariant.Int,       self.cb_auto_l, 26, None],
+            ["AZ",          QVariant.Int,       self.cb_auto_z, 27, 22  ]
         ]
 
         self.is_opening = True

--- a/mesh_tools/styles/culvert.qml
+++ b/mesh_tools/styles/culvert.qml
@@ -1279,6 +1279,16 @@
         </config>
       </editWidget>
     </field>
+    <field name="NB_in_//">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
   </fieldConfiguration>
   <aliases>
     <alias field="NAME" name="" index="0"/>
@@ -1311,6 +1321,7 @@
     <alias field="AZ" name="" index="27"/>
     <alias field="AA" name="" index="28"/>
     <alias field="Remarques" name="" index="29"/>
+    <alias field="NB_in_//" name="" index="30"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
@@ -1345,6 +1356,7 @@
     <default field="AZ" applyOnUpdate="0" expression="0"/>
     <default field="AA" applyOnUpdate="0" expression="0"/>
     <default field="Remarques" applyOnUpdate="0" expression=""/>
+    <default field="NB_in_//" applyOnUpdate="0" expression="1"/>
   </defaults>
   <constraints>
     <constraint field="NAME" notnull_strength="0" unique_strength="0" exp_strength="0" constraints="0"/>
@@ -1377,6 +1389,7 @@
     <constraint field="AZ" notnull_strength="1" unique_strength="0" exp_strength="0" constraints="1"/>
     <constraint field="AA" notnull_strength="1" unique_strength="0" exp_strength="0" constraints="1"/>
     <constraint field="Remarques" notnull_strength="0" unique_strength="0" exp_strength="0" constraints="0"/>
+    <constraint field="NB_in_//" notnull_strength="1" unique_strength="0" exp_strength="0" constraints="1"/>
   </constraints>
   <constraintExpressions>
     <constraint field="NAME" exp="" desc=""/>
@@ -1409,6 +1422,7 @@
     <constraint field="AZ" exp="" desc=""/>
     <constraint field="AA" exp="" desc=""/>
     <constraint field="Remarques" exp="" desc=""/>
+    <constraint field="NB_in_//" exp="" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <editform tolerant="1"></editform>
@@ -1464,6 +1478,7 @@ def my_form_open(dialog, layer, feature):
     <field name="d2" editable="1"/>
     <field name="z1" editable="1"/>
     <field name="z2" editable="1"/>
+    <field name="NB_in_//" editable="1"/>
   </editable>
   <labelOnTop>
     <field name="AA" labelOnTop="0"/>
@@ -1496,6 +1511,7 @@ def my_form_open(dialog, layer, feature):
     <field name="d2" labelOnTop="0"/>
     <field name="z1" labelOnTop="0"/>
     <field name="z2" labelOnTop="0"/>
+    <field name="NB_in_//" labelOnTop="0"/>
   </labelOnTop>
   <widgets/>
   <layerGeometryType>1</layerGeometryType>

--- a/mesh_tools/ui/culvert_manager.ui
+++ b/mesh_tools/ui/culvert_manager.ui
@@ -262,6 +262,20 @@ A relaxation coefficient of 0.2 means that 20% of time T result is mixed with 80
              <item>
               <widget class="QLineEdit" name="txt_name"/>
              </item>
+             <item>
+              <widget class="QLabel" name="label_nbre">
+               <property name="text">
+                <string>Number in //</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="sb_nbre">
+               <property name="minimum">
+                <number>1</number>
+               </property>
+              </widget>
+             </item>
             </layout>
            </widget>
           </item>


### PR DESCRIPTION
This will allow the possibility to indicate the number of similar parallel structure.
The value is written at the end of the line So it shouldn't be read by telemac an then doesn't change the computation.
This will easy to take this parameter into account for telemac if needed (just read the value and multiply the computed discharge)

Deactivation of unused fields for Uhaina
