### PR TITLE
feat: migrate plugin to qgis 4 / Qt6 compatibility

### DIFF
--- a/mesh_tools/libs/MeshUtils.py
+++ b/mesh_tools/libs/MeshUtils.py
@@ -27,6 +27,7 @@ import functools
 from typing import Optional
 
 from qgis.core import (
+    Qgis,
     QgsCoordinateTransform,
     QgsFeature,
     QgsGeometry,
@@ -45,7 +46,7 @@ from qgis.PyQt.QtWidgets import QApplication
 class MeshUtils:
     @staticmethod
     def pointInMesh(mesh: QgsMeshLayer, point: QgsPointXY) -> bool:
-        return not mesh.snapOnElement(QgsMesh.Face, point, 0).isEmpty()
+        return not mesh.snapOnElement(QgsMesh.ElementType.Face, point, 0).isEmpty()
 
     @staticmethod
     def findNearestVertex(
@@ -115,7 +116,7 @@ class MeshUtils:
         # to layer CRS.
         if mesh_xorm is not None and layer_xform is not None:
             point = mesh_xorm.transform(point)
-            point = layer_xform.transform(point, QgsCoordinateTransform.ReverseTransform)
+            point = layer_xform.transform(point, Qgis.TransformDirection.Reverse)
 
         return point, error
 
@@ -176,7 +177,7 @@ class MeshUtils:
 def showWaitCursor(func):
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
-        QApplication.setOverrideCursor(Qt.WaitCursor)
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
         try:
             return func(*args, **kwargs)
         finally:

--- a/mesh_tools/libs/create_shp_dlg.py
+++ b/mesh_tools/libs/create_shp_dlg.py
@@ -81,7 +81,7 @@ class dlg_create_shapefile(QDialog, FORM_CLASS):
                 self,
                 self.tr("Error", self.__class__.__name__),
                 self.tr("Select a file.", self.__class__.__name__),
-                QMessageBox.Ok,
+                QMessageBox.StandardButton.Ok,
             )
             self.cur_shp = None
             return
@@ -93,7 +93,7 @@ class dlg_create_shapefile(QDialog, FORM_CLASS):
                 self,
                 self.tr("Error", self.__class__.__name__),
                 self.tr("Select a projection.", self.__class__.__name__),
-                QMessageBox.Ok,
+                QMessageBox.StandardButton.Ok,
             )
             return
 

--- a/mesh_tools/libs/culvert_manager.py
+++ b/mesh_tools/libs/culvert_manager.py
@@ -33,14 +33,13 @@ import numpy as np
 from processing.algs.gdal.GdalUtils import GdalUtils
 from qgis.core import (
     NULL,
+    Qgis,
     QgsCoordinateTransform,
     QgsCoordinateTransformContext,
     QgsFeature,
     QgsField,
     QgsFields,
     QgsGeometry,
-    QgsMapLayerProxyModel,
-    QgsMapLayerType,
     QgsMesh,
     QgsMeshDatasetIndex,
     QgsPointXY,
@@ -48,7 +47,7 @@ from qgis.core import (
     QgsVectorLayer,
 )
 from qgis.PyQt import uic
-from qgis.PyQt.QtCore import QVariant, pyqtSignal
+from qgis.PyQt.QtCore import QMetaType, Qt, pyqtSignal
 from qgis.PyQt.QtGui import QStandardItem, QStandardItemModel
 from qgis.PyQt.QtWidgets import (
     QCheckBox,
@@ -101,36 +100,36 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
         # Col4 - Index for Telemac
         # Col5 - Index for Uhaina
         self.culv_flds = [
-            ["NAME",        QVariant.String,    self.txt_name,  28, 23  ],
-            ["N1",          QVariant.Int,       None,           0,  None],
-            ["N2",          QVariant.Int,       None,           1,  None],
-            ["CE1",         QVariant.Double,    self.sb_ce1,    2, 6    ],
-            ["CE2",         QVariant.Double,    self.sb_ce2,    3, 7    ],
-            ["CS1",         QVariant.Double,    self.sb_cs1,    4, 8    ],
-            ["CS2",         QVariant.Double,    self.sb_cs2,    5, 9    ],
-            ["LARG",        QVariant.Double,    self.sb_larg,   6, 17   ],
-            ["HAUT",        QVariant.Double,    self.sb_haut1,  7, 18   ],
-            ["CLAP",        QVariant.String,    self.cb_clapet, 8, 20   ],
-            ["L12",         QVariant.Double,    self.sb_l12,    9, 10   ],
-            ["Z1",          QVariant.Double,    self.sb_z1,     10, 2   ],
-            ["Z2",          QVariant.Double,    self.sb_z2,     11, 5   ],
-            ["CV",          QVariant.Double,    self.sb_cv,     12, None],
-            ["C56",         QVariant.Double,    self.sb_c56,    13, None],
-            ["CV5",         QVariant.Double,    self.sb_cv5,    14, None],
-            ["C5",          QVariant.Double,    self.sb_c5,     15, None],
-            ["CT",          QVariant.Double,    self.sb_ct,     16, None],
-            ["HAUT2",       QVariant.Double,    self.sb_haut2,  17, 19  ],
-            ["FRIC",        QVariant.Double,    self.sb_fric,   18, None],
-            ["LENGTH",      QVariant.Double,    self.sb_length, 19, None],
-            ["CIRC",        QVariant.Int,       self.cb_circ,   20, 16  ],
-            ["d1",          QVariant.Double,    self.sb_d1,     21, 11  ],
-            ["d2",          QVariant.Double,    self.sb_d2,     22, 12  ],
-            ["a1",          QVariant.Double,    self.sb_a1,     23, 14  ],
-            ["a2",          QVariant.Double,    self.sb_a2,     24, 15  ],
-            ["AA",          QVariant.Int,       self.cb_auto_a, 25, 13  ],
-            ["NB_in_//",    QVariant.Int,       self.sb_nbre,   None, 21  ],
-            ["AL",          QVariant.Int,       self.cb_auto_l, 26, None],
-            ["AZ",          QVariant.Int,       self.cb_auto_z, 27, 22  ]
+            ["NAME",        QMetaType.Type.QString,  self.txt_name,  28, 23  ],
+            ["N1",          QMetaType.Type.Int,      None,           0,  None],
+            ["N2",          QMetaType.Type.Int,      None,           1,  None],
+            ["CE1",         QMetaType.Type.Double,   self.sb_ce1,    2, 6    ],
+            ["CE2",         QMetaType.Type.Double,   self.sb_ce2,    3, 7    ],
+            ["CS1",         QMetaType.Type.Double,   self.sb_cs1,    4, 8    ],
+            ["CS2",         QMetaType.Type.Double,   self.sb_cs2,    5, 9    ],
+            ["LARG",        QMetaType.Type.Double,   self.sb_larg,   6, 17   ],
+            ["HAUT",        QMetaType.Type.Double,   self.sb_haut1,  7, 18   ],
+            ["CLAP",        QMetaType.Type.QString,  self.cb_clapet, 8, 20   ],
+            ["L12",         QMetaType.Type.Double,   self.sb_l12,    9, 10   ],
+            ["Z1",          QMetaType.Type.Double,   self.sb_z1,     10, 2   ],
+            ["Z2",          QMetaType.Type.Double,   self.sb_z2,     11, 5   ],
+            ["CV",          QMetaType.Type.Double,   self.sb_cv,     12, None],
+            ["C56",         QMetaType.Type.Double,   self.sb_c56,    13, None],
+            ["CV5",         QMetaType.Type.Double,   self.sb_cv5,    14, None],
+            ["C5",          QMetaType.Type.Double,   self.sb_c5,     15, None],
+            ["CT",          QMetaType.Type.Double,   self.sb_ct,     16, None],
+            ["HAUT2",       QMetaType.Type.Double,   self.sb_haut2,  17, 19  ],
+            ["FRIC",        QMetaType.Type.Double,   self.sb_fric,   18, None],
+            ["LENGTH",      QMetaType.Type.Double,   self.sb_length, 19, None],
+            ["CIRC",        QMetaType.Type.Int,      self.cb_circ,   20, 16  ],
+            ["d1",          QMetaType.Type.Double,   self.sb_d1,     21, 11  ],
+            ["d2",          QMetaType.Type.Double,   self.sb_d2,     22, 12  ],
+            ["a1",          QMetaType.Type.Double,   self.sb_a1,     23, 14  ],
+            ["a2",          QMetaType.Type.Double,   self.sb_a2,     24, 15  ],
+            ["AA",          QMetaType.Type.Int,      self.cb_auto_a, 25, 13  ],
+            ["NB_in_//",    QMetaType.Type.Int,      self.sb_nbre,   None, 21  ],
+            ["AL",          QMetaType.Type.Int,      self.cb_auto_l, 26, None],
+            ["AZ",          QMetaType.Type.Int,      self.cb_auto_z, 27, 22  ]
         ]
         # fmt: on
 
@@ -151,7 +150,7 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
         self.project.layersAdded.connect(self.addLayers)
         self.project.layersRemoved.connect(self.removeLayers)
 
-        self.cb_lay_mesh.setFilters(QgsMapLayerProxyModel.MeshLayer)
+        self.cb_lay_mesh.setFilters(Qgis.LayerFilter.MeshLayer)
         self.cb_lay_mesh.layerChanged.connect(self.mesh_lay_changed)
         self.cb_lay_culv.currentIndexChanged.connect(self.culv_lay_changed)
         self.cb_dataset_mesh.currentIndexChanged.connect(self.mesh_dataset_changed)
@@ -197,7 +196,7 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
                 self.mdl_lay_culv.takeRow(r)
 
     def analyse_layer(self, lay):
-        if lay.type() == QgsMapLayerType.VectorLayer:
+        if lay.type() == Qgis.LayerType.Vector:
             flds = [f.name() for f in lay.fields()]
             if all(elem in flds for elem in [fc[0] for fc in self.culv_flds]):
                 itm = QStandardItem()
@@ -359,9 +358,9 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
                             "Mesh parameters have been changed.\n"
                             "Update culvert features with Automatic Z checked ?"
                         ),
-                        QMessageBox.Cancel | QMessageBox.Ok,
+                        QMessageBox.StandardButton.Cancel | QMessageBox.StandardButton.Ok,
                     )
-                    == QMessageBox.Ok
+                    == QMessageBox.StandardButton.Ok
                 ):
                     self.update_all_auto_z()
 
@@ -377,8 +376,8 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
         if self.lay_mesh:
             srs_mesh = self.lay_mesh.crs()
         dlg = dlg_create_shapefile(self.tr("culvert"), srs_mesh, self)
-        dlg.setWindowModality(2)
-        if dlg.exec_():
+        dlg.setWindowModality(Qt.WindowModality.WindowModal)
+        if dlg.exec():
             path, crs = dlg.cur_shp, dlg.cur_crs
         if path:
             self.create_new_shp(path, crs)
@@ -443,9 +442,9 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
                             "Culvert layer has been changed.\n"
                             "Update culvert features with Automatic Z checked ?"
                         ),
-                        QMessageBox.Cancel | QMessageBox.Ok,
+                        QMessageBox.StandardButton.Cancel | QMessageBox.StandardButton.Ok,
                     )
-                    == QMessageBox.Ok
+                    == QMessageBox.StandardButton.Ok
                 ):
                     self.update_all_auto_z()
         else:
@@ -493,7 +492,7 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
                 elif isinstance(ctrl, QComboBox):
                     ctrl.setCurrentIndex(0)
                 elif isinstance(ctrl, QCheckBox):
-                    ctrl.setCheckState(0)
+                    ctrl.setCheckState(Qt.CheckState.Unchecked)
                 elif isinstance(ctrl, QLineEdit):
                     ctrl.setText("")
         self.ctrl_signal_blocked = False
@@ -525,9 +524,9 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
                 ctrl.setCurrentIndex(idx)
         elif isinstance(ctrl, QCheckBox):
             if val == 1:
-                ctrl.setCheckState(2)
+                ctrl.setCheckState(Qt.CheckState.Checked)
             else:
-                ctrl.setCheckState(0)
+                ctrl.setCheckState(Qt.CheckState.Unchecked)
         elif isinstance(ctrl, QLineEdit):
             ctrl.setText(str(val))
 
@@ -543,7 +542,7 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
                 elif isinstance(ctrl, QComboBox):
                     val = ctrl.currentIndex()
                 elif isinstance(ctrl, QCheckBox):
-                    if ctrl.checkState() == 2:
+                    if ctrl.checkState() == Qt.CheckState.Checked:
                         val = 1
                     else:
                         val = 0
@@ -634,7 +633,7 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
                 elif isinstance(ctrl, QComboBox):
                     ctrl.setCurrentIndex(0)
                 elif isinstance(ctrl, QCheckBox):
-                    ctrl.setCheckState(0)
+                    ctrl.setCheckState(Qt.CheckState.Unchecked)
 
     def update_all_n(self, log=True):
         attrs = dict()
@@ -760,12 +759,12 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
 
                     # pt1 and pt2 need to be transformed into mesh CRS
                     pt1 = self.lay_mesh_xform.transform(
-                        self.lay_culv_xform.transform(pt1, QgsCoordinateTransform.ReverseTransform),
-                        QgsCoordinateTransform.ReverseTransform,
+                        self.lay_culv_xform.transform(pt1, Qgis.TransformDirection.Reverse),
+                        Qgis.TransformDirection.Reverse,
                     )
                     pt2 = self.lay_mesh_xform.transform(
-                        self.lay_culv_xform.transform(pt2, QgsCoordinateTransform.ReverseTransform),
-                        QgsCoordinateTransform.ReverseTransform,
+                        self.lay_culv_xform.transform(pt2, Qgis.TransformDirection.Reverse),
+                        Qgis.TransformDirection.Reverse,
                     )
 
                 for fld in culv_flds_srtd[:-1]:
@@ -801,17 +800,17 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
 
             for fld in self.culv_flds:
                 if fld[0] not in ["NAME", "Remarques"] and fld[2]:
-                    if fld[1] == QVariant.String:
+                    if fld[1] == QMetaType.Type.QString:
                         if (ft[fld[0]] == NULL) or not isinstance(ft[fld[0]], str):
                             selectedids.append(
                                 [ft_name, self.tr("{} value is not correct.").format(fld[0])]
                             )
-                    elif fld[1] == QVariant.Double:
+                    elif fld[1] == QMetaType.Type.Double:
                         if (ft[fld[0]] == NULL) or not isinstance(ft[fld[0]], float):
                             selectedids.append(
                                 [ft_name, self.tr("{} value is not correct.").format(fld[0])]
                             )
-                    elif fld[1] == QVariant.Int:
+                    elif fld[1] == QMetaType.Type.Int:
                         if (ft[fld[0]] == NULL) or not isinstance(ft[fld[0]], int):
                             selectedids.append(
                                 [ft_name, self.tr("{} value is not correct.").format(fld[0])]
@@ -856,8 +855,8 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
 
         culv_flds = [x[0] for x in self.culv_flds]
         dlg = dlg_import_culvert_file(culv_flds, mesh_crs, self)
-        dlg.setWindowModality(2)
-        if dlg.exec_():
+        dlg.setWindowModality(Qt.WindowModality.WindowModal)
+        if dlg.exec():
             items = dlg.items
             self.cb_software_select.setCurrentIndex(dlg.cb_soft.currentIndex())
             txt_path = dlg.text_file.filePath()
@@ -937,7 +936,7 @@ class CulvertManager(MeshToolsDockWidget, FORM_CLASS):
                     if key:
                         attr = values[key]
                     else:
-                        if fld[1] in [QVariant.Int, QVariant.Double]:
+                        if fld[1] in [QMetaType.Type.Int, QMetaType.Type.Double]:
                             attr = 0
                         else:
                             attr = ""

--- a/mesh_tools/libs/dialog_for_CAS.py
+++ b/mesh_tools/libs/dialog_for_CAS.py
@@ -39,7 +39,7 @@ class DialogForCAS(QDialog, FORM_CLASS):
         font = QFont()
         font.setFamily("monospace [Consolas]")
         font.setFixedPitch(True)
-        font.setStyleHint(QFont.TypeWriter)
+        font.setStyleHint(QFont.StyleHint.TypeWriter)
 
         self.textBrowser.setFont(font)
 

--- a/mesh_tools/libs/import_culvert_file_dlg.py
+++ b/mesh_tools/libs/import_culvert_file_dlg.py
@@ -46,11 +46,11 @@ class dlg_import_culvert_file(QDialog, FORM_CLASS):
 
         self.updateTable()
 
-        self.text_file.setStorageMode(QgsFileWidget.GetFile)
+        self.text_file.setStorageMode(QgsFileWidget.StorageMode.GetFile)
         self.text_file.setDialogTitle(self.tr("Select file"))
         self.text_file.setFilter(self.tr("Text Files (*.txt);;All Files (*.*)"))
 
-        self.layer_file.setStorageMode(QgsFileWidget.SaveFile)
+        self.layer_file.setStorageMode(QgsFileWidget.StorageMode.SaveFile)
         self.layer_file.setConfirmOverwrite(True)
         self.layer_file.setDialogTitle(self.tr("Select file"))
         self.layer_file.setFilter("ESRI Shapefile (*.shp)")

--- a/mesh_tools/libs/mesh_quality.py
+++ b/mesh_tools/libs/mesh_quality.py
@@ -26,7 +26,7 @@
 import math
 import os
 
-from qgis.core import QgsCoordinateTransform, QgsMapLayerProxyModel, QgsMesh, QgsPointXY
+from qgis.core import Qgis, QgsCoordinateTransform, QgsMesh, QgsPointXY
 from qgis.gui import QgsVertexMarker
 from qgis.PyQt import uic
 from qgis.PyQt.QtGui import QColor
@@ -51,7 +51,7 @@ class MeshQuality(MeshToolsDockWidget, FORM_CLASS):
 
         self.markers = []
 
-        self.mMapLayerComboBox.setFilters(QgsMapLayerProxyModel.MeshLayer)
+        self.mMapLayerComboBox.setFilters(Qgis.LayerFilter.MeshLayer)
         self.mMapLayerComboBox.layerChanged.connect(self.mesh_lay_changed)
 
         self.mesh_lay_changed()

--- a/mesh_tools/libs/mesh_translation_dlg.py
+++ b/mesh_tools/libs/mesh_translation_dlg.py
@@ -27,8 +27,8 @@ import os
 from pyproj import CRS
 from pyproj.exceptions import CRSError
 from qgis.core import (
+    Qgis,
     QgsCoordinateReferenceSystem,
-    QgsMapLayerProxyModel,
     QgsMeshLayer,
     QgsProject,
 )
@@ -74,7 +74,7 @@ class MeshTranslation(MeshToolsDockWidget, FORM_CLASS):
         self.bt_valid.accepted.connect(self.valide_trans)
         self.bt_valid.rejected.connect(self.reject)
 
-        self.qcb_layer.setFilters(QgsMapLayerProxyModel.MeshLayer)
+        self.qcb_layer.setFilters(Qgis.LayerFilter.MeshLayer)
         self.qcb_layer.setAdditionalItems(["Import file"])
         self.qcb_layer.layerChanged.connect(self.change_qcb_layer)
         self.change_qcb_layer()

--- a/mesh_tools/libs/source_manager.py
+++ b/mesh_tools/libs/source_manager.py
@@ -31,13 +31,12 @@ from contextlib import suppress
 from processing.algs.gdal.GdalUtils import GdalUtils
 from qgis.core import (
     NULL,
+    Qgis,
     QgsCoordinateTransform,
     QgsCoordinateTransformContext,
     QgsField,
     QgsFields,
     QgsGeometry,
-    QgsMapLayerProxyModel,
-    QgsMapLayerType,
     QgsMesh,
     QgsPointXY,
     QgsVectorFileWriter,
@@ -45,7 +44,7 @@ from qgis.core import (
 )
 from qgis.gui import QgsVertexMarker
 from qgis.PyQt import uic
-from qgis.PyQt.QtCore import QVariant, pyqtSignal
+from qgis.PyQt.QtCore import QMetaType, Qt, pyqtSignal
 from qgis.PyQt.QtGui import QColor, QStandardItem, QStandardItemModel
 from qgis.PyQt.QtWidgets import QFileDialog
 
@@ -80,9 +79,9 @@ class SourceManager(MeshToolsDockWidget, FORM_CLASS):
         self.src_type = None
 
         self.src_flds = [
-            ("srcId", QVariant.Int, None),
-            (self.tr("Name"), QVariant.String, self.txt_name),
-            (self.tr("Note"), QVariant.String, self.txt_note),
+            ("srcId", QMetaType.Type.Int, None),
+            (self.tr("Name"), QMetaType.Type.QString, self.txt_name),
+            (self.tr("Note"), QMetaType.Type.QString, self.txt_note),
         ]
 
         self.is_opening = True
@@ -94,7 +93,7 @@ class SourceManager(MeshToolsDockWidget, FORM_CLASS):
         self.project.layersAdded.connect(self.addLayers)
         self.project.layersRemoved.connect(self.removeLayers)
 
-        self.cb_lay_mesh.setFilters(QgsMapLayerProxyModel.MeshLayer)
+        self.cb_lay_mesh.setFilters(Qgis.LayerFilter.MeshLayer)
         self.cb_lay_mesh.layerChanged.connect(self.mesh_lay_changed)
         self.cb_type_src.currentIndexChanged.connect(self.src_type_changed)
         self.cb_lay_src.currentIndexChanged.connect(self.src_lay_changed)
@@ -129,7 +128,7 @@ class SourceManager(MeshToolsDockWidget, FORM_CLASS):
             self.analyse_layer(lay)
 
     def analyse_layer(self, lay):
-        if not lay.type() == QgsMapLayerType.VectorLayer:
+        if not lay.type() == Qgis.LayerType.Vector:
             return
 
         if lay.geometryType() != self.src_type:
@@ -222,8 +221,8 @@ class SourceManager(MeshToolsDockWidget, FORM_CLASS):
         if self.lay_mesh:
             srs_mesh = self.lay_mesh.crs()
         dlg = dlg_create_shapefile(self.tr("source"), srs_mesh, self)
-        dlg.setWindowModality(2)
-        if dlg.exec_():
+        dlg.setWindowModality(Qt.WindowModality.WindowModal)
+        if dlg.exec():
             path, crs = dlg.cur_shp, dlg.cur_crs
         if path:
             self.create_new_shp(path, crs)
@@ -426,7 +425,7 @@ class SourceManager(MeshToolsDockWidget, FORM_CLASS):
         for feat in self.lay_src.getFeatures():
             point = feat.geometry().asPoint()
             point = self.lay_src_xform.transform(point)
-            point = self.lay_mesh_xform.transform(point, QgsCoordinateTransform.ReverseTransform)
+            point = self.lay_mesh_xform.transform(point, Qgis.TransformDirection.Reverse)
             xs.append(str(round(point.x(), 4)))
             ys.append(str(round(point.y(), 4)))
 
@@ -471,7 +470,7 @@ class SourceManager(MeshToolsDockWidget, FORM_CLASS):
 
                 for point in geom[:-1]:
                     point = self.lay_src_xform.transform(point)
-                    point = self.lay_mesh_xform.transform(point, QgsCoordinateTransform.ReverseTransform)
+                    point = self.lay_mesh_xform.transform(point, Qgis.TransformDirection.Reverse)
                     src_file.write(f"{round(point.x(), 4)}\t{round(point.y(), 4)}\n")
             src_file.write("#")
 

--- a/mesh_tools/mesh_tools.py
+++ b/mesh_tools/mesh_tools.py
@@ -248,5 +248,5 @@ class MeshTools:
             self.dockwidget.setWindowTitle(self.tr("MeshTool - Error"))
 
         self.dockwidget.closingPlugin.connect(self.onClosePlugin)
-        self.iface.addDockWidget(Qt.RightDockWidgetArea, self.dockwidget)
+        self.iface.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, self.dockwidget)
         self.dockwidget.show()

--- a/mesh_tools/mesh_tools_dockwidget.py
+++ b/mesh_tools/mesh_tools_dockwidget.py
@@ -60,7 +60,7 @@ class MeshToolsDockWidget(QDockWidget):
 
     def write_log(self, txt, mode="Info"):
         self.log.setTextColor(QColor("black"))
-        self.log.setFontWeight(QFont.Bold)
+        self.log.setFontWeight(QFont.Weight.Bold)
         self.log.append(f"{datetime.now().strftime('%H:%M:%S')} - ")
         if mode == "Success":
             self.log.setTextColor(QColor("green"))
@@ -70,7 +70,7 @@ class MeshToolsDockWidget(QDockWidget):
             self.log.setTextColor(QColor("red"))
         elif mode == "Warning":
             self.log.setTextColor(QColor("orange"))
-        self.log.setFontWeight(QFont.Normal)
+        self.log.setFontWeight(QFont.Weight.Normal)
         self.log.insertPlainText(txt)
         self.log.verticalScrollBar().setValue(self.log.verticalScrollBar().maximum())
 

--- a/mesh_tools/metadata.txt
+++ b/mesh_tools/metadata.txt
@@ -3,10 +3,10 @@
 # Mandatory items:
 [general]
 name=Mesh Tools
-qgisMinimumVersion=3.16
-qgisMaximumVersion=3.99
+qgisMinimumVersion=3.40
+qgisMaximumVersion=4.99
 description=Tools for management of Data on mesh (Telemac, Uhaina).
-version=0.8.5
+version=0.9.0
 author=Artelia
 email=a@a
 
@@ -26,6 +26,7 @@ repository=https://github.com/Artelia/mesh_tools
 hasProcessingProvider=no
 # Uncomment the following line and add your changelog:
 changelog=
+   0.9.0 : QGIS 4 compatibility
    0.8.5 : Addition of the view translation for a Serafin file
    0.8.4 : Fix larg and haut2 value to haut1 value for circular culvert (#58)
    0.8.3 : Fix export source region (duplicated vertex)

--- a/mesh_tools/ui/mesh_quality.ui
+++ b/mesh_tools/ui/mesh_quality.ui
@@ -232,7 +232,7 @@
           <item row="0" column="1">
            <widget class="QComboBox" name="mCbSize">
             <property name="sizeAdjustPolicy">
-             <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+             <enum>QComboBox::AdjustToContents</enum>
             </property>
             <item>
              <property name="text">


### PR DESCRIPTION
Hi,
This PR migrate the plugin to QGIS 4 and ensure Qt6 compatibility.

- Bump qgis minimum version from 3.16 to 3.40 and maximum version to 4.99
- Replace unscoped Qt enums
- Replace QVariant.Type with QMetaType.Type
- Replace deprecated QGIS API
- Rename exec_() to exec()
- Fix .ui file: ComboBox::AdjustToMinimumContentsLength replaced with QComboBox::AdjustToContents